### PR TITLE
Migrate tanstack example to flow-css

### DIFF
--- a/examples/tanstack-start/package.json
+++ b/examples/tanstack-start/package.json
@@ -16,7 +16,6 @@
     "@tanstack/react-start": "^1.131.43",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwind-merge": "^2.6.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {
@@ -25,9 +24,6 @@
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^4.6.0",
-    "autoprefixer": "^10.4.20",
-    "postcss": "^8.5.1",
-    "tailwindcss": "^3.4.17",
     "typescript": "^5.7.2",
     "vite": "^6.3.5",
     "vite-tsconfig-paths": "^5.1.4"

--- a/examples/tanstack-start/postcss.config.mjs
+++ b/examples/tanstack-start/postcss.config.mjs
@@ -1,6 +1,0 @@
-export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}

--- a/examples/tanstack-start/src/components/DefaultCatchBoundary.tsx
+++ b/examples/tanstack-start/src/components/DefaultCatchBoundary.tsx
@@ -6,6 +6,7 @@ import {
   useRouter,
 } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
+import { css } from '@flow-css/core/css'
 
 export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter()
@@ -17,28 +18,85 @@ export function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   console.error('DefaultCatchBoundary Error:', error)
 
   return (
-    <div className="min-w-0 flex-1 p-4 flex flex-col items-center justify-center gap-6">
+    <div className={css({
+      minWidth: "0",
+      flex: "1",
+      padding: "1rem",
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: "1.5rem",
+    })}>
       <ErrorComponent error={error} />
-      <div className="flex gap-2 items-center flex-wrap">
+      <div className={css({
+        display: "flex",
+        gap: "0.5rem",
+        alignItems: "center",
+        flexWrap: "wrap",
+      })}>
         <button
           onClick={() => {
             router.invalidate()
           }}
-          className={`px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded text-white uppercase font-extrabold`}
+          className={css({
+            paddingLeft: "0.5rem",
+            paddingRight: "0.5rem",
+            paddingTop: "0.25rem",
+            paddingBottom: "0.25rem",
+            backgroundColor: "#4b5563",
+            borderRadius: "0.25rem",
+            color: "white",
+            textTransform: "uppercase",
+            fontWeight: "800",
+            border: "none",
+            cursor: "pointer",
+            "@media (prefers-color-scheme: dark)": {
+              backgroundColor: "#374151",
+            },
+          })}
         >
           Try Again
         </button>
         {isRoot ? (
           <Link
             to="/"
-            className={`px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded text-white uppercase font-extrabold`}
+            className={css({
+              paddingLeft: "0.5rem",
+              paddingRight: "0.5rem",
+              paddingTop: "0.25rem",
+              paddingBottom: "0.25rem",
+              backgroundColor: "#4b5563",
+              borderRadius: "0.25rem",
+              color: "white",
+              textTransform: "uppercase",
+              fontWeight: "800",
+              textDecoration: "none",
+              "@media (prefers-color-scheme: dark)": {
+                backgroundColor: "#374151",
+              },
+            })}
           >
             Home
           </Link>
         ) : (
           <Link
             to="/"
-            className={`px-2 py-1 bg-gray-600 dark:bg-gray-700 rounded text-white uppercase font-extrabold`}
+            className={css({
+              paddingLeft: "0.5rem",
+              paddingRight: "0.5rem",
+              paddingTop: "0.25rem",
+              paddingBottom: "0.25rem",
+              backgroundColor: "#4b5563",
+              borderRadius: "0.25rem",
+              color: "white",
+              textTransform: "uppercase",
+              fontWeight: "800",
+              textDecoration: "none",
+              "@media (prefers-color-scheme: dark)": {
+                backgroundColor: "#374151",
+              },
+            })}
             onClick={(e) => {
               e.preventDefault()
               window.history.back()

--- a/examples/tanstack-start/src/components/NotFound.tsx
+++ b/examples/tanstack-start/src/components/NotFound.tsx
@@ -1,21 +1,62 @@
 import { Link } from '@tanstack/react-router'
+import { css } from '@flow-css/core/css'
 
 export function NotFound({ children }: { children?: any }) {
   return (
-    <div className="space-y-2 p-2">
-      <div className="text-gray-600 dark:text-gray-400">
+    <div className={css({
+      display: "flex",
+      flexDirection: "column",
+      gap: "0.5rem",
+      padding: "0.5rem",
+    })}>
+      <div className={css({
+        color: "#6b7280",
+        "@media (prefers-color-scheme: dark)": {
+          color: "#9ca3af",
+        },
+      })}>
         {children || <p>The page you are looking for does not exist.</p>}
       </div>
-      <p className="flex items-center gap-2 flex-wrap">
+      <p className={css({
+        display: "flex",
+        alignItems: "center",
+        gap: "0.5rem",
+        flexWrap: "wrap",
+      })}>
         <button
           onClick={() => window.history.back()}
-          className="bg-emerald-500 text-white px-2 py-1 rounded uppercase font-black text-sm"
+          className={css({
+            backgroundColor: "#10b981",
+            color: "white",
+            paddingLeft: "0.5rem",
+            paddingRight: "0.5rem",
+            paddingTop: "0.25rem",
+            paddingBottom: "0.25rem",
+            borderRadius: "0.25rem",
+            textTransform: "uppercase",
+            fontWeight: "900",
+            fontSize: "0.875rem",
+            border: "none",
+            cursor: "pointer",
+          })}
         >
           Go back
         </button>
         <Link
           to="/"
-          className="bg-cyan-600 text-white px-2 py-1 rounded uppercase font-black text-sm"
+          className={css({
+            backgroundColor: "#0891b2",
+            color: "white",
+            paddingLeft: "0.5rem",
+            paddingRight: "0.5rem",
+            paddingTop: "0.25rem",
+            paddingBottom: "0.25rem",
+            borderRadius: "0.25rem",
+            textTransform: "uppercase",
+            fontWeight: "900",
+            fontSize: "0.875rem",
+            textDecoration: "none",
+          })}
         >
           Start Over
         </Link>

--- a/examples/tanstack-start/src/routes/__root.tsx
+++ b/examples/tanstack-start/src/routes/__root.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 import * as React from "react";
+import { css } from "@flow-css/core/css";
 import { DefaultCatchBoundary } from "~/components/DefaultCatchBoundary";
 import { NotFound } from "~/components/NotFound";
 // Import CSS normally to enable Flow CSS processing
@@ -72,11 +73,18 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <HeadContent />
       </head>
       <body>
-        <div className="p-2 flex gap-2 text-lg">
+        <div className={css({
+          padding: "0.5rem",
+          display: "flex",
+          gap: "0.5rem",
+          fontSize: "1.125rem",
+        })}>
           <Link
             to="/"
             activeProps={{
-              className: "font-bold",
+              className: css({
+                fontWeight: "bold",
+              }),
             }}
             activeOptions={{ exact: true }}
           >
@@ -85,7 +93,9 @@ function RootDocument({ children }: { children: React.ReactNode }) {
           <Link
             to="/posts"
             activeProps={{
-              className: "font-bold",
+              className: css({
+                fontWeight: "bold",
+              }),
             }}
           >
             Posts
@@ -93,7 +103,9 @@ function RootDocument({ children }: { children: React.ReactNode }) {
           <Link
             to="/users"
             activeProps={{
-              className: "font-bold",
+              className: css({
+                fontWeight: "bold",
+              }),
             }}
           >
             Users
@@ -101,7 +113,9 @@ function RootDocument({ children }: { children: React.ReactNode }) {
           <Link
             to="/route-a"
             activeProps={{
-              className: "font-bold",
+              className: css({
+                fontWeight: "bold",
+              }),
             }}
           >
             Pathless Layout
@@ -109,7 +123,9 @@ function RootDocument({ children }: { children: React.ReactNode }) {
           <Link
             to="/deferred"
             activeProps={{
-              className: "font-bold",
+              className: css({
+                fontWeight: "bold",
+              }),
             }}
           >
             Deferred
@@ -118,7 +134,9 @@ function RootDocument({ children }: { children: React.ReactNode }) {
             // @ts-expect-error
             to="/this-route-does-not-exist"
             activeProps={{
-              className: "font-bold",
+              className: css({
+                fontWeight: "bold",
+              }),
             }}
           >
             This Route Does Not Exist

--- a/examples/tanstack-start/src/routes/_pathlessLayout.tsx
+++ b/examples/tanstack-start/src/routes/_pathlessLayout.tsx
@@ -1,4 +1,5 @@
 import { Outlet, createFileRoute } from '@tanstack/react-router'
+import { css } from '@flow-css/core/css'
 
 export const Route = createFileRoute('/_pathlessLayout')({
   component: LayoutComponent,
@@ -6,8 +7,8 @@ export const Route = createFileRoute('/_pathlessLayout')({
 
 function LayoutComponent() {
   return (
-    <div className="p-2">
-      <div className="border-b">I'm a layout</div>
+    <div className={css({ padding: "0.5rem" })}>
+      <div className={css({ borderBottom: "1px solid #e5e7eb" })}>I'm a layout</div>
       <div>
         <Outlet />
       </div>

--- a/examples/tanstack-start/src/routes/_pathlessLayout/_nested-layout.tsx
+++ b/examples/tanstack-start/src/routes/_pathlessLayout/_nested-layout.tsx
@@ -1,4 +1,5 @@
 import { Link, Outlet, createFileRoute } from '@tanstack/react-router'
+import { css } from '@flow-css/core/css'
 
 export const Route = createFileRoute('/_pathlessLayout/_nested-layout')({
   component: LayoutComponent,
@@ -8,11 +9,17 @@ function LayoutComponent() {
   return (
     <div>
       <div>I'm a nested layout</div>
-      <div className="flex gap-2 border-b">
+      <div className={css({
+        display: "flex",
+        gap: "0.5rem",
+        borderBottom: "1px solid #e5e7eb",
+      })}>
         <Link
           to="/route-a"
           activeProps={{
-            className: 'font-bold',
+            className: css({
+              fontWeight: "bold",
+            }),
           }}
         >
           Go to route A
@@ -20,7 +27,9 @@ function LayoutComponent() {
         <Link
           to="/route-b"
           activeProps={{
-            className: 'font-bold',
+            className: css({
+              fontWeight: "bold",
+            }),
           }}
         >
           Go to route B

--- a/examples/tanstack-start/src/routes/deferred.tsx
+++ b/examples/tanstack-start/src/routes/deferred.tsx
@@ -1,6 +1,7 @@
 import { Await, createFileRoute } from '@tanstack/react-router'
 import { createServerFn } from '@tanstack/react-start'
 import { Suspense, useState } from 'react'
+import { css } from '@flow-css/core/css'
 
 const personServerFn = createServerFn({ method: 'GET' })
   .validator((d: string) => d)
@@ -33,7 +34,7 @@ function Deferred() {
   const { deferredStuff, deferredPerson, person } = Route.useLoaderData()
 
   return (
-    <div className="p-2">
+    <div className={css({ padding: "0.5rem" })}>
       <div data-testid="regular-person">
         {person.name} - {person.randomNumber}
       </div>

--- a/examples/tanstack-start/src/routes/posts.$postId.tsx
+++ b/examples/tanstack-start/src/routes/posts.$postId.tsx
@@ -1,4 +1,5 @@
 import { Link, createFileRoute } from '@tanstack/react-router'
+import { css } from '@flow-css/core/css'
 import { fetchPost } from '../utils/posts'
 import { NotFound } from '~/components/NotFound'
 import { PostErrorComponent } from '~/components/PostError'
@@ -16,16 +17,37 @@ function PostComponent() {
   const post = Route.useLoaderData()
 
   return (
-    <div className="space-y-2">
-      <h4 className="text-xl font-bold underline">{post.title}</h4>
-      <div className="text-sm">{post.body}</div>
+    <div className={css({
+      display: "flex",
+      flexDirection: "column",
+      gap: "0.5rem",
+    })}>
+      <h4 className={css({
+        fontSize: "1.25rem",
+        fontWeight: "bold",
+        textDecoration: "underline",
+      })}>{post.title}</h4>
+      <div className={css({
+        fontSize: "0.875rem",
+      })}>{post.body}</div>
       <Link
         to="/posts/$postId/deep"
         params={{
           postId: post.id,
         }}
-        activeProps={{ className: 'text-black font-bold' }}
-        className="inline-block py-1 text-blue-800 hover:text-blue-600"
+        activeProps={{ className: css({
+          color: "#000",
+          fontWeight: "bold",
+        }) }}
+        className={css({
+          display: "inline-block",
+          paddingTop: "0.25rem",
+          paddingBottom: "0.25rem",
+          color: "#1e40af",
+          "&:hover": {
+            color: "#2563eb",
+          },
+        })}
       >
         Deep View
       </Link>

--- a/examples/tanstack-start/src/routes/posts.tsx
+++ b/examples/tanstack-start/src/routes/posts.tsx
@@ -1,4 +1,5 @@
 import { Link, Outlet, createFileRoute } from '@tanstack/react-router'
+import { css } from '@flow-css/core/css'
 import { fetchPosts } from '../utils/posts'
 
 export const Route = createFileRoute('/posts')({
@@ -10,19 +11,39 @@ function PostsComponent() {
   const posts = Route.useLoaderData()
 
   return (
-    <div className="p-2 flex gap-2">
-      <ul className="list-disc pl-4">
+    <div className={css({
+      padding: "0.5rem",
+      display: "flex",
+      gap: "0.5rem",
+    })}>
+      <ul className={css({
+        listStyleType: "disc",
+        paddingLeft: "1rem",
+      })}>
         {[...posts, { id: 'i-do-not-exist', title: 'Non-existent Post' }].map(
           (post) => {
             return (
-              <li key={post.id} className="whitespace-nowrap">
+              <li key={post.id} className={css({
+                whiteSpace: "nowrap",
+              })}>
                 <Link
                   to="/posts/$postId"
                   params={{
                     postId: post.id,
                   }}
-                  className="block py-1 text-blue-800 hover:text-blue-600"
-                  activeProps={{ className: 'text-black font-bold' }}
+                  className={css({
+                    display: "block",
+                    paddingTop: "0.25rem",
+                    paddingBottom: "0.25rem",
+                    color: "#1e40af",
+                    "&:hover": {
+                      color: "#2563eb",
+                    },
+                  })}
+                  activeProps={{ className: css({
+                    color: "#000",
+                    fontWeight: "bold",
+                  }) }}
                 >
                   <div>{post.title.substring(0, 20)}</div>
                 </Link>

--- a/examples/tanstack-start/src/routes/posts_.$postId.deep.tsx
+++ b/examples/tanstack-start/src/routes/posts_.$postId.deep.tsx
@@ -1,4 +1,5 @@
 import { Link, createFileRoute } from '@tanstack/react-router'
+import { css } from '@flow-css/core/css'
 import { fetchPost } from '../utils/posts'
 import { PostErrorComponent } from '~/components/PostError'
 
@@ -15,15 +16,34 @@ function PostDeepComponent() {
   const post = Route.useLoaderData()
 
   return (
-    <div className="p-2 space-y-2">
+    <div className={css({
+      padding: "0.5rem",
+      display: "flex",
+      flexDirection: "column",
+      gap: "0.5rem",
+    })}>
       <Link
         to="/posts"
-        className="block py-1 text-blue-800 hover:text-blue-600"
+        className={css({
+          display: "block",
+          paddingTop: "0.25rem",
+          paddingBottom: "0.25rem",
+          color: "#1e40af",
+          "&:hover": {
+            color: "#2563eb",
+          },
+        })}
       >
         ← All Posts
       </Link>
-      <h4 className="text-xl font-bold underline">{post.title}</h4>
-      <div className="text-sm">{post.body}</div>
+      <h4 className={css({
+        fontSize: "1.25rem",
+        fontWeight: "bold",
+        textDecoration: "underline",
+      })}>{post.title}</h4>
+      <div className={css({
+        fontSize: "0.875rem",
+      })}>{post.body}</div>
     </div>
   )
 }

--- a/examples/tanstack-start/src/routes/users.$userId.tsx
+++ b/examples/tanstack-start/src/routes/users.$userId.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { css } from '@flow-css/core/css'
 import { NotFound } from 'src/components/NotFound'
 import { UserErrorComponent } from 'src/components/UserError'
 
@@ -28,13 +29,29 @@ function UserComponent() {
   const user = Route.useLoaderData()
 
   return (
-    <div className="space-y-2">
-      <h4 className="text-xl font-bold underline">{user.name}</h4>
-      <div className="text-sm">{user.email}</div>
+    <div className={css({
+      display: "flex",
+      flexDirection: "column",
+      gap: "0.5rem",
+    })}>
+      <h4 className={css({
+        fontSize: "1.25rem",
+        fontWeight: "bold",
+        textDecoration: "underline",
+      })}>{user.name}</h4>
+      <div className={css({
+        fontSize: "0.875rem",
+      })}>{user.email}</div>
       <div>
         <a
           href={`/api/users/${user.id}`}
-          className="text-blue-800 hover:text-blue-600 underline"
+          className={css({
+            color: "#1e40af",
+            textDecoration: "underline",
+            "&:hover": {
+              color: "#2563eb",
+            },
+          })}
         >
           View as JSON
         </a>

--- a/examples/tanstack-start/src/routes/users.index.tsx
+++ b/examples/tanstack-start/src/routes/users.index.tsx
@@ -1,4 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { css } from '@flow-css/core/css'
+
 export const Route = createFileRoute('/users/')({
   component: UsersIndexComponent,
 })
@@ -9,7 +11,13 @@ function UsersIndexComponent() {
       Select a user or{' '}
       <a
         href="/api/users"
-        className="text-blue-800 hover:text-blue-600 underline"
+        className={css({
+          color: "#1e40af",
+          textDecoration: "underline",
+          "&:hover": {
+            color: "#2563eb",
+          },
+        })}
       >
         view as JSON
       </a>

--- a/examples/tanstack-start/tailwind.config.mjs
+++ b/examples/tanstack-start/tailwind.config.mjs
@@ -1,4 +1,0 @@
-/** @type {import('tailwindcss').Config} */
-export default {
-  content: ['./src/**/*.{js,jsx,ts,tsx}'],
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,9 +219,6 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
-      tailwind-merge:
-        specifier: ^2.6.0
-        version: 2.6.0
       zod:
         specifier: ^3.24.2
         version: 3.25.76
@@ -241,15 +238,6 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.6.0
         version: 4.7.0(vite@6.3.6(@types/node@22.18.3)(jiti@2.5.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1))
-      autoprefixer:
-        specifier: ^10.4.20
-        version: 10.4.21(postcss@8.5.6)
-      postcss:
-        specifier: ^8.5.1
-        version: 8.5.6
-      tailwindcss:
-        specifier: ^3.4.17
-        version: 3.4.17
       typescript:
         specifier: ^5.7.2
         version: 5.8.3
@@ -405,10 +393,6 @@ packages:
   '@algolia/requester-node-http@5.35.0':
     resolution: {integrity: sha512-RgLX78ojYOrThJHrIiPzT4HW3yfQa0D7K+MQ81rhxqaNyNBu4F1r+72LNHYH/Z+y9I1Mrjrd/c/Ue5zfDgAEjQ==}
     engines: {node: '>= 14.0.0'}
-
-  '@alloc/quick-lru@5.2.0':
-    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
-    engines: {node: '>=10'}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -3476,10 +3460,6 @@ packages:
   camel-case@4.1.2:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
 
-  camelcase-css@2.0.1:
-    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
-    engines: {node: '>= 6'}
-
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
@@ -4047,9 +4027,6 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  didyoumean@1.2.2:
-    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
-
   diff@8.0.2:
     resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
     engines: {node: '>=0.3.1'}
@@ -4057,9 +4034,6 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
-
-  dlv@1.1.3:
-    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
@@ -5757,10 +5731,6 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
-  object-hash@3.0.0:
-    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
-    engines: {node: '>= 6'}
-
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -5973,10 +5943,6 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
-  pify@2.3.0:
-    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
-    engines: {node: '>=0.10.0'}
-
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -6128,35 +6094,11 @@ packages:
     peerDependencies:
       postcss: ^8.4
 
-  postcss-import@15.1.0:
-    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      postcss: ^8.0.0
-
-  postcss-js@4.0.1:
-    resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
-    engines: {node: ^12 || ^14 || >= 16}
-    peerDependencies:
-      postcss: ^8.4.21
-
   postcss-lab-function@7.0.10:
     resolution: {integrity: sha512-tqs6TCEv9tC1Riq6fOzHuHcZyhg4k3gIAMB8GGY/zA1ssGdm6puHMVE7t75aOSoFg7UD2wyrFFhbldiCMyyFTQ==}
     engines: {node: '>=18'}
     peerDependencies:
       postcss: ^8.4
-
-  postcss-load-config@4.0.2:
-    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
-    engines: {node: '>= 14'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
@@ -6254,12 +6196,6 @@ packages:
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
-
-  postcss-nested@6.2.0:
-    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
-    engines: {node: '>=12.0'}
-    peerDependencies:
-      postcss: ^8.2.14
 
   postcss-nesting@13.0.2:
     resolution: {integrity: sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ==}
@@ -6623,9 +6559,6 @@ packages:
   react@19.1.1:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
     engines: {node: '>=0.10.0'}
-
-  read-cache@1.0.0:
-    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
@@ -7207,14 +7140,6 @@ packages:
   system-architecture@0.1.0:
     resolution: {integrity: sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==}
     engines: {node: '>=18'}
-
-  tailwind-merge@2.6.0:
-    resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
-
-  tailwindcss@3.4.17:
-    resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
 
   tapable@2.2.2:
     resolution: {integrity: sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==}
@@ -8126,8 +8051,6 @@ snapshots:
   '@algolia/requester-node-http@5.35.0':
     dependencies:
       '@algolia/client-common': 5.35.0
-
-  '@alloc/quick-lru@5.2.0': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -12138,8 +12061,6 @@ snapshots:
       pascal-case: 3.1.2
       tslib: 2.8.1
 
-  camelcase-css@2.0.1: {}
-
   camelcase@6.3.0: {}
 
   camelcase@7.0.1: {}
@@ -12669,15 +12590,11 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  didyoumean@1.2.2: {}
-
   diff@8.0.2: {}
 
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
-
-  dlv@1.1.3: {}
 
   dns-packet@5.6.1:
     dependencies:
@@ -14906,8 +14823,6 @@ snapshots:
 
   object-assign@4.1.1: {}
 
-  object-hash@3.0.0: {}
-
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
@@ -15114,8 +15029,6 @@ snapshots:
 
   picomatch@4.0.3: {}
 
-  pify@2.3.0: {}
-
   pirates@4.0.7: {}
 
   pkg-dir@7.0.0:
@@ -15267,18 +15180,6 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  postcss-import@15.1.0(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
-      postcss-value-parser: 4.2.0
-      read-cache: 1.0.0
-      resolve: 1.22.10
-
-  postcss-js@4.0.1(postcss@8.5.6):
-    dependencies:
-      camelcase-css: 2.0.1
-      postcss: 8.5.6
-
   postcss-lab-function@7.0.10(postcss@8.5.6):
     dependencies:
       '@csstools/css-color-parser': 3.0.10(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
@@ -15286,13 +15187,6 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       '@csstools/postcss-progressive-custom-properties': 4.1.0(postcss@8.5.6)
       '@csstools/utilities': 2.0.0(postcss@8.5.6)
-      postcss: 8.5.6
-
-  postcss-load-config@4.0.2(postcss@8.5.6):
-    dependencies:
-      lilconfig: 3.1.3
-      yaml: 2.8.1
-    optionalDependencies:
       postcss: 8.5.6
 
   postcss-load-config@6.0.1(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(yaml@2.8.1):
@@ -15383,11 +15277,6 @@ snapshots:
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
-
-  postcss-nested@6.2.0(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
-      postcss-selector-parser: 6.1.2
 
   postcss-nesting@13.0.2(postcss@8.5.6):
     dependencies:
@@ -15777,10 +15666,6 @@ snapshots:
   react@19.1.0: {}
 
   react@19.1.1: {}
-
-  read-cache@1.0.0:
-    dependencies:
-      pify: 2.3.0
 
   readable-stream@2.3.8:
     dependencies:
@@ -16551,35 +16436,6 @@ snapshots:
       picocolors: 1.1.1
 
   system-architecture@0.1.0: {}
-
-  tailwind-merge@2.6.0: {}
-
-  tailwindcss@3.4.17:
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.6.0
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.3
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.21.7
-      lilconfig: 3.1.3
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-import: 15.1.0(postcss@8.5.6)
-      postcss-js: 4.0.1(postcss@8.5.6)
-      postcss-load-config: 4.0.2(postcss@8.5.6)
-      postcss-nested: 6.2.0(postcss@8.5.6)
-      postcss-selector-parser: 6.1.2
-      resolve: 1.22.10
-      sucrase: 3.35.0
-    transitivePeerDependencies:
-      - ts-node
 
   tapable@2.2.2: {}
 
@@ -17362,7 +17218,8 @@ snapshots:
 
   yallist@5.0.0: {}
 
-  yaml@2.8.1: {}
+  yaml@2.8.1:
+    optional: true
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
Migrate the `tanstack-start` example from Tailwind CSS to flow-css and remove all Tailwind dependencies.

---
<a href="https://cursor.com/background-agent?bcId=bc-47b674c0-2bd4-4cdc-bf2a-ff411bdb727a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-47b674c0-2bd4-4cdc-bf2a-ff411bdb727a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

