### PR TITLE
feat: build guardrail for missing @flow-css; directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,26 @@ export default nextConfig;
 
 Use the theme by passing a function to the `css()` function:
 
+## Troubleshooting
+
+### Build fails with "no CSS file contains the @flow-css; directive"
+
+Flow CSS requires at least one CSS file in your project to contain the `@flow-css;` directive. This is where generated styles are injected at build time. Without it, `css()` calls produce class names that reference styles that don't exist, resulting in unstyled elements in production.
+
+**Fix:** Add `@flow-css;` to a CSS file that is imported in your application entry point:
+
+```css
+/* e.g. src/index.css or app/globals.css */
+@flow-css;
+
+/* your other styles... */
+body {
+  margin: 0;
+}
+```
+
+This directive tells Flow CSS where to inject the generated class definitions. You only need it in one CSS file, but it must be imported (directly or transitively) by your application.
+
 ```tsx
 import { css } from "@flow-css/core/css";
 

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -1,0 +1,29 @@
+---
+sidebar_position: 5
+---
+
+# Troubleshooting
+
+Common issues and their solutions when working with Flow CSS.
+
+## Build fails with "no CSS file contains the @flow-css; directive"
+
+Flow CSS requires at least one CSS file in your project to contain the `@flow-css;` directive. This is where generated styles are injected at build time. Without it, `css()` calls produce class names that reference styles that don't exist, resulting in unstyled elements in production.
+
+**Fix:** Add `@flow-css;` to a CSS file that is imported in your application entry point:
+
+```css
+/* e.g. src/index.css or app/globals.css */
+@flow-css;
+
+/* your other styles... */
+body {
+  margin: 0;
+}
+```
+
+This directive tells Flow CSS where to inject the generated class definitions. You only need it in one CSS file, but it must be imported (directly or transitively) by your application.
+
+:::tip
+If you followed the [Vite setup](./installation/vite) or [Next.js setup](./installation/nextjs) guides, the `@flow-css;` directive is included in step 1 ("Add Global CSS Directive"). This error typically occurs when the directive is accidentally removed or when starting from a custom setup.
+:::

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -66,4 +66,33 @@ export class Registry {
   get styleRoots() {
     return Array.from(this.#styleRoots);
   }
+
+  /**
+   * Check if there are registered styles but no CSS file with `@flow-css;` directive.
+   * Returns a diagnostic object indicating whether the configuration is valid.
+   */
+  validateStyleRoots(): {
+    valid: boolean;
+    styleCount: number;
+    rootCount: number;
+    message: string | null;
+  } {
+    const styleCount = Object.keys(this.#styles).length;
+    const rootCount = this.#styleRoots.size;
+
+    if (styleCount > 0 && rootCount === 0) {
+      return {
+        valid: false,
+        styleCount,
+        rootCount,
+        message:
+          `[flow-css] Found ${styleCount} css() call(s) but no CSS file contains the @flow-css; directive. ` +
+          `Generated styles will not be injected and elements will be unstyled. ` +
+          `Add @flow-css; to a CSS file that is imported in your application (e.g. index.css or globals.css). ` +
+          `See: https://github.com/0916dhkim/flow-css#usage`,
+      };
+    }
+
+    return { valid: true, styleCount, rootCount, message: null };
+  }
 }

--- a/packages/core/src/transformer.ts
+++ b/packages/core/src/transformer.ts
@@ -30,10 +30,13 @@ export class Transformer {
       generated
     );
 
-    this.#registry.addRoot(id);
+    if (transformed.hasFlowDirective) {
+      this.#registry.addRoot(id);
+    }
 
     return {
-      code: transformed,
+      code: transformed.code,
+      hasFlowDirective: transformed.hasFlowDirective,
     };
   }
 
@@ -88,7 +91,7 @@ export class Transformer {
     id: string,
     originalString: string,
     generatedString: string
-  ) {
+  ): { code: string; hasFlowDirective: boolean } {
     const originalRoot = result(() => postcss.parse(originalString))
       .catch((e) => {
         console.error(e);
@@ -103,10 +106,15 @@ export class Transformer {
       })
       .done();
 
+    let hasFlowDirective = false;
     originalRoot.walkAtRules("flow-css", (atRule) => {
-      atRule.replaceWith(generatedRoot);
+      hasFlowDirective = true;
+      atRule.replaceWith(generatedRoot.clone());
     });
 
-    return originalRoot.toString();
+    return {
+      code: originalRoot.toString(),
+      hasFlowDirective,
+    };
   }
 }

--- a/packages/core/src/validate-style-roots.test.ts
+++ b/packages/core/src/validate-style-roots.test.ts
@@ -1,0 +1,55 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import { Registry } from "./registry.js";
+
+test("validateStyleRoots: valid when no styles and no roots", () => {
+  const registry = new Registry({});
+  const result = registry.validateStyleRoots();
+  assert.strictEqual(result.valid, true);
+  assert.strictEqual(result.styleCount, 0);
+  assert.strictEqual(result.rootCount, 0);
+  assert.strictEqual(result.message, null);
+});
+
+test("validateStyleRoots: valid when styles exist and root is registered", () => {
+  const registry = new Registry({});
+  registry.addStyle({ background: "red" }, "/app/component.tsx");
+  registry.addRoot("/app/index.css");
+  const result = registry.validateStyleRoots();
+  assert.strictEqual(result.valid, true);
+  assert.strictEqual(result.styleCount, 1);
+  assert.strictEqual(result.rootCount, 1);
+  assert.strictEqual(result.message, null);
+});
+
+test("validateStyleRoots: invalid when styles exist but no root", () => {
+  const registry = new Registry({});
+  registry.addStyle({ background: "red" }, "/app/component.tsx");
+  const result = registry.validateStyleRoots();
+  assert.strictEqual(result.valid, false);
+  assert.strictEqual(result.styleCount, 1);
+  assert.strictEqual(result.rootCount, 0);
+  assert.ok(result.message!.includes("@flow-css;"));
+  assert.ok(result.message!.includes("1 css() call(s)"));
+});
+
+test("validateStyleRoots: invalid with multiple styles and no root", () => {
+  const registry = new Registry({});
+  registry.addStyle({ background: "red" }, "/app/a.tsx");
+  registry.addStyle({ color: "blue" }, "/app/b.tsx");
+  const result = registry.validateStyleRoots();
+  assert.strictEqual(result.valid, false);
+  assert.strictEqual(result.styleCount, 2);
+  assert.strictEqual(result.rootCount, 0);
+  assert.ok(result.message!.includes("2 css() call(s)"));
+});
+
+test("validateStyleRoots: valid with multiple roots", () => {
+  const registry = new Registry({});
+  registry.addStyle({ background: "red" }, "/app/component.tsx");
+  registry.addRoot("/app/index.css");
+  registry.addRoot("/app/globals.css");
+  const result = registry.validateStyleRoots();
+  assert.strictEqual(result.valid, true);
+  assert.strictEqual(result.rootCount, 2);
+});

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -16,11 +16,13 @@ export default function flowCssVitePlugin(
   const registry = new Registry({ theme: pluginConfig.theme });
   let scanner: Scanner | null = null;
   let transformer: Transformer | null = null;
+  let isBuild = false;
 
   return [
     {
       name: "flow-css:config",
       async configResolved(config) {
+        isBuild = config.command === "build";
         scanner = new Scanner(config.root, registry, fs);
         await scanner.scanAll();
         transformer = new Transformer({
@@ -32,6 +34,13 @@ export default function flowCssVitePlugin(
             );
           },
         });
+      },
+      buildEnd() {
+        if (!isBuild) return;
+        const validation = registry.validateStyleRoots();
+        if (!validation.valid) {
+          throw new Error(validation.message!);
+        }
       },
     },
     {

--- a/packages/webpack/src/css-loader.ts
+++ b/packages/webpack/src/css-loader.ts
@@ -20,9 +20,6 @@ const webpackCssLoader: LoaderDefinitionFunction = function (
     const { registry, transformer } = await Context.get();
 
     try {
-      // Register this CSS file as a style root for HMR tracking
-      registry.addRoot(filePath);
-
       const result = await transformer.transformCss(code, filePath);
 
       if (result == null) {

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -40,6 +40,15 @@ class FlowCssPlugin {
     // The plugin adds the loaders for asset files (like ts or css source files).
     // The loaders transform the files.
     eventSource.addListener("beforeLoaders")(injectFlowCssLoaders);
+
+    // Build guardrail: fail if css() calls exist but no @flow-css; directive found
+    compiler.hooks.emit.tapPromise("FlowCssPlugin", async () => {
+      const { registry } = await Context.get();
+      const validation = registry.validateStyleRoots();
+      if (!validation.valid) {
+        throw new Error(validation.message!);
+      }
+    });
   }
 }
 


### PR DESCRIPTION
## Problem

When a project uses `css()` calls in JS/TS files but no CSS file contains the `@flow-css;` directive, the build completes silently — producing class names that reference styles that were never injected. This results in completely unstyled elements in production with no indication of what went wrong.

## Solution

Added a build-time validation that checks whether any CSS "style root" (a file containing `@flow-css;`) has been registered when `css()` calls are detected. If styles exist but no root is found, the build fails with an actionable error:

```
[flow-css] Found 3 css() call(s) but no CSS file contains the @flow-css; directive.
Generated styles will not be injected and elements will be unstyled.
Add @flow-css; to a CSS file that is imported in your application (e.g. index.css or globals.css).
```

### Changes

- **`@flow-css/core`**: Added `Registry.validateStyleRoots()` method with diagnostic return type
- **`@flow-css/vite`**: Validate in `buildEnd` hook (production builds only)
- **`@flow-css/webpack`**: Validate in `emit` hook
- **Transformer fix**: `transformCss` now correctly returns `hasFlowDirective`, and `addRoot` is only called when the directive is actually present (was previously unconditional)
- **Webpack css-loader**: Removed redundant `addRoot` call (now handled inside `transformer.transformCss`)
- **Tests**: 5 new unit tests covering all validation scenarios
- **README**: Added troubleshooting section

### Migration

No breaking changes for correctly configured projects. If your build fails after this change, it means `@flow-css;` was missing and your styles were already not being applied. Add `@flow-css;` to any imported CSS file to fix:

```css
/* e.g. src/index.css */
@flow-css;
```